### PR TITLE
Make tracker name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Vue.use(VueMatomo, {
   // Whether to track the initial page view
   // Default: true
   trackInitialView: true
+
+  // Changes the default .js and .php endpoint's filename
+  // Default: 'piwik'
+  trackerName: 'piwik'
 })
 
 // Now you can access piwik api in components through

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,6 +1,6 @@
 export default function (options) {
-  const { host } = options
-  const filename = host + '/piwik.js'
+  const { host, trackerName } = options
+  const filename = `${host}/${trackerName || 'piwik'}.js`
 
   const scriptPromise = new Promise((resolve, reject) => {
     const script = document.createElement('script')
@@ -17,7 +17,7 @@ export default function (options) {
 
   scriptPromise.catch((error) => {
     const msg = '[vue-matomo] An error occurred trying to load ' + error.target.src + '. ' +
-            'If the file exists you may have an ad- or trackingblocker enabled.'
+      'If the file exists you may have an ad- or trackingblocker enabled.'
 
     console.error(msg)
   })

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,8 @@ export default function install (Vue, setupOptions = {}) {
 
   bootstrap(options)
     .then(() => {
-      const { host, siteId } = options
-      const matomo = window.Piwik.getTracker(host + '/piwik.php', siteId)
+      const { host, siteId, trackerName } = options
+      const matomo = window.Piwik.getTracker(`${host}/${trackerName || 'piwik'}.php`, siteId)
 
       // Assign matomo to Vue
       Vue.prototype.$piwik = matomo


### PR DESCRIPTION
I needed this feature to circumvent the adblocking of the piwik.js and piwik.php like in [this](https://github.com/matomo-org/matomo/issues/7364#issuecomment-318023296) issue.
