### PR TITLE
Allow custom tracker URLs without php extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ import Vue from 'vue'
 import VueMatomo from 'vue-matomo'
 
 Vue.use(VueMatomo, {
-  // Configure your matomo server and site
+  // Configure your matomo server and site by providing host and trackerFileName
   host: 'https://matomo.example.com',
+  // Changes the default .js and .php endpoint's filename
+  // Default: 'piwik'
+  trackerFileName: 'piwik',
+  // or provide a custom tracker url instead
+  // trackerUrl: 'https://matomo.example.com/piwik.php',
+
   siteId: 5,
 
   // Enables automatically registering pageviews on the router
@@ -40,10 +46,6 @@ Vue.use(VueMatomo, {
   // Whether to track the initial page view
   // Default: true
   trackInitialView: true,
-
-  // Changes the default .js and .php endpoint's filename
-  // Default: 'piwik'
-  trackerFileName: 'piwik',
 
   // Whether or not to log debug information
   // Default: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-matomo",
-  "version": "3.7.0-1",
+  "version": "3.7.0-2",
   "description": "Link your Piwik/Matomo installation",
   "author": "Dennis Ruhe <dennis@amazingsystems.nl>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,11 @@ const defaultOptions = {
 export default function install (Vue, setupOptions = {}) {
   const options = Object.assign({}, defaultOptions, setupOptions)
 
-  const { host, siteId, trackerFileName } = options
-  const Matomo = MatomoJS.getTracker(`${host}/${trackerFileName}.php`, siteId)
+  const { host, siteId, trackerFileName, trackerUrl } = options
+
+  const trackerEnpoint = trackerUrl || `${host}/${trackerFileName}.php`;
+
+  const Matomo = MatomoJS.getTracker(trackerEnpoint, siteId)
 
   // Assign matomo to Vue
   Vue.prototype.$piwik = Matomo


### PR DESCRIPTION
We are using a proxy for matomo to prevent us from CORS which doesn't have php endpoint. This would be very helpful :-)