### PR TITLE
Fix double slash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,8 @@ function initMatomo(Vue, options) {
 
   // Track page navigations if router is specified
   if (options.router) {
-    const baseUrl         = buildBaseUrl(options)
+    const baseUrl = buildBaseUrl(options)
+
     const baseUrlHasSlash = baseUrl.slice(-1) === '/'
 
     options.router.afterEach((to, from) => {

--- a/src/index.js
+++ b/src/index.js
@@ -52,12 +52,13 @@ function initMatomo(Vue, options) {
 
   // Track page navigations if router is specified
   if (options.router) {
-    const baseUrl = buildBaseUrl(options)
+    const baseUrl         = buildBaseUrl(options)
+    const baseUrlHasSlash = baseUrl.slice(-1) === '/'
 
     options.router.afterEach((to, from) => {
       // Unfortunately the window location is not yet updated here
       // We need to make our own url using the data provided by the router
-      const url = baseUrl + to.fullPath
+      const url = baseUrl + (baseUrlHasSlash ? to.fullPath.replace(/^\//, '') : to.fullPath)
 
       if (to.meta.analyticsIgnore) {
         options.debug && console.debug('[vue-matomo] Ignoring ' + url)


### PR DESCRIPTION
For example, if router.options.base is "/" and the path of a route begins with a slash (e.g. "/help"), the reported url is of the form "http://www.example.com//help" on navigation after the initial load.