### PR TITLE
fix reject error when src is undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,8 +100,13 @@ export default function install (Vue, setupOptions = {}) {
   loadScript(trackerScript)
     .then(() => initMatomo(Vue, options))
     .catch((error) => {
-      const msg = '[vue-matomo] An error occurred trying to load ' + error.target.src + '. ' +
-        'If the file exists you may have an ad- or trackingblocker enabled.'
-      console.error(msg)
-    })
+      let msg;
+      if (error.target){
+        msg = `[vue-matomo] An error occurred trying to load ${error.target.src}. `
+          + 'If the file exists you may have an ad- or trackingblocker enabled.';
+      } else {
+        msg = error;
+      }
+      console.error(msg);
+    });
 }


### PR DESCRIPTION
-  the catch can throw `src of target undefined` (following [PR#48](https://github.com/AmazingDreams/vue-matomo/pull/48)) when the error is thrown from initMatomo
