### PR TITLE
set custom url after route change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,8 +51,12 @@ function initMatomo (Vue, options) {
 
   // Track page navigations if router is specified
   if (options.router) {
-    options.router.afterEach(() => {
+    options.router.afterEach((to, from) => {
       Vue.nextTick(() => {
+        // Make matomo aware of the route change
+        Matomo.setReferrerUrl(from.fullPath)
+        Matomo.setCustomUrl(to.fullPath)
+        
         trackMatomoPageView(options, Matomo)
 
         if (options.enableLinkTracking) {


### PR DESCRIPTION
Set a custom url after each route change. See https://developer.matomo.org/guides/spa-tracking.
Fixes #60 