### PR TITLE
Do not track hash updates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,9 @@ function initMatomo (Vue, options) {
   // Track page navigations if router is specified
   if (options.router) {
     options.router.afterEach((to, from) => {
+      if (from.fullPath === to.fullPath) {
+        return; 
+      }
       Vue.nextTick(() => {
         // Make matomo aware of the route change
         Matomo.setReferrerUrl(from.fullPath)


### PR DESCRIPTION
I am often updating my url with `this.router.replace({ hash: '2020-05-28' });`.
Hash updates are registered by `router.afterEach`, but `to.fullPath` only contains the url without the hash part, so I get 1000s of updates with the same url.