### PR TITLE
add fallback for route meta title

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ function trackMatomoPageView (options) {
 
     options.debug && console.debug('[vue-matomo] Tracking ' + url)
 
-    title = meta.title || options.router.currentRoute.path
+    title = meta.title || url.pathname
   }
 
   getMatomo().trackPageView(title)

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ function trackMatomoPageView (options) {
 
     options.debug && console.debug('[vue-matomo] Tracking ' + url)
 
-    title = meta.title
+    title = meta.title || options.router.currentRoute.path
   }
 
   getMatomo().trackPageView(title)


### PR DESCRIPTION
when running matomo in a nuxt ssr environment, meta information are not provided by the router so a fallback for the action title is needed.