### PR TITLE
Add requireCookieConsent

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Vue.use(VueMatomo, {
   // Default: false
   disableCookies: false,
 
+  // Require consent before creating matomo session cookie
+  // Default: false
+  requireCookieConsent: false,
+
   // Enable the heartbeat timer (https://developer.matomo.org/guides/tracking-javascript-guide#accurately-measure-the-time-spent-on-each-page)
   // Default: false
   enableHeartBeatTimer: false,
@@ -184,7 +188,7 @@ It is possible to ignore routes using the route meta:
 }
 ```
 
-### Managing consent
+### Managing tracking consent
 
 First of all load the plugin with the `requireConsent` option enabled:
 
@@ -198,7 +202,7 @@ Vue.use(VueMatomo, {
 Matomo has a built in way to give and remember consent. The simplest way is to simply use this method provided by Matomo:
 
 ```js
-<button @click="handleConsent()">Accept Cookies</button>
+<button @click="handleConsent()">Accept Tracking</button>
 
 handleConsent() {
   this.$matomo.rememberConsentGiven()
@@ -207,6 +211,32 @@ handleConsent() {
 
 Another option is to use your own implementation for remembering consent. In that case you can simply call
 `this.$matomo.setConsentGiven()` on each page load when you establish that the user has given consent.
+
+### Managing cookie consent
+
+You can use Matomo Analytics without consent and cookie banner. For more information see [matomo faq: "How do I use matomo analytics without consent or cookie banner?](https://matomo.org/faq/new-to-piwik/how-do-i-use-matomo-analytics-without-consent-or-cookie-banner/).
+
+First of all load the plugin with the `requireCookieConsent` option enabled:
+
+```js
+Vue.use(VueMatomo, {
+  // ...
+  requireCookieConsent: true
+})
+```
+
+Matomo has a built in way to give and remember consent. The simplest way is to simply use this method provided by Matomo:
+
+```js
+<button @click="handleConsent()">Accept Cookies</button>
+
+handleConsent() {
+  this.$matomo.rememberCookieConsentGiven()
+}
+```
+
+Another option is to use your own implementation for remembering cookie consent. In that case you can simply call
+`this.$matomo.setCookieConsentGiven()` on each page load when you establish that the user has given cookie consent.
 
 ## Build
 

--- a/demo/vue-2/src/main.js
+++ b/demo/vue-2/src/main.js
@@ -30,6 +30,10 @@ Vue.use(VueMatomo, {
   // Default: false
   disableCookies: false,
 
+  // Require consent before creating matomo session cookie
+  // Default: false
+  requireCookieConsent: false,
+
   // Enable the heartbeat timer (https://developer.matomo.org/guides/tracking-javascript-guide#accurately-measure-the-time-spent-on-each-page)
   // Default: false
   enableHeartBeatTimer: true,

--- a/demo/vue-3/src/main.js
+++ b/demo/vue-3/src/main.js
@@ -32,6 +32,10 @@ createApp(App)
     // Default: false
     disableCookies: false,
 
+    // Require consent before creating matomo session cookie
+    // Default: false
+    requireCookieConsent: false,
+
     // Enable the heartbeat timer (https://developer.matomo.org/guides/tracking-javascript-guide#accurately-measure-the-time-spent-on-each-page)
     // Default: false
     enableHeartBeatTimer: true,

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { getMatomo, getResolvedHref, loadScript } from './utils'
 const defaultOptions = {
   debug: false,
   disableCookies: false,
+  requireCookieConsent: false,
   enableHeartBeatTimer: false,
   enableLinkTracking: true,
   heartBeatTimerInterval: 15,
@@ -139,6 +140,10 @@ export default function install (Vue, setupOptions = {}) {
 
   if (options.disableCookies) {
     window._paq.push(['disableCookies'])
+  }
+
+  if (options.requireCookieConsent) {
+    window._paq.push(['requireCookieConsent'])
   }
 
   if (options.enableHeartBeatTimer) {


### PR DESCRIPTION
Hello,

we are using Matomo in our project and we are on a zero-cookie-track. Therefore, we are using Matomo on our static website with "requireCookieConsent: true". This enables tracking without using cookies. Matomo will not create a MATOMO_SESSION cookie then. "disableCookies" disables all cookies but not the session cookie.
For more information you can read [Matomo FAQ: How do I use Matomo Analytics without consent or cookie banner?](https://matomo.org/faq/new-to-piwik/how-do-i-use-matomo-analytics-without-consent-or-cookie-banner/) and [Matomo FAQ: How do I track a visitor without cookies when they have not given consent for tracking cookies?](https://matomo.org/faq/new-to-piwik/how-can-i-still-track-a-visitor-without-cookies-even-if-they-decline-the-cookie-consent/).

I didn't add any tests as requested in [CONTRIBUTING.md](https://github.com/AmazingDreams/vue-matomo/blob/master/CONTRIBUTING.md) because there is currently no test suite.