### PR TITLE
Fix for Vue 3.1 Migration Build: Better Version-Switch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,15 +55,15 @@ function trackMatomoPageView (options, to, from) {
 function initMatomo (Vue, options) {
   const Matomo = getMatomo()
 
-  if (Vue.prototype) {
-    // Assign matomo to Vue 2
-    Vue.prototype.$piwik = Matomo
-    Vue.prototype.$matomo = Matomo
-  } else {
-    // Assign matomo to Vue 3
+  const version = Number(Vue.version.split('.')[0])
+
+  if (version > 2) {
     Vue.config.globalProperties.$piwik = Matomo
     Vue.config.globalProperties.$matomo = Matomo
     Vue.provide(matomoKey, Matomo)
+  } else {
+    Vue.prototype.$piwik = Matomo
+    Vue.prototype.$matomo = Matomo
   }
 
   if (options.trackInitialView && options.router) {


### PR DESCRIPTION
The Migration Build (Vue 3.1) provide a bride for vue 2. Unfortunately this leads to break this Lib because it relies on functionnames (that are now provided by the migration build)

See: 
- Getting Version number: https://v3.vuejs.org/api/application-api.html#version
- https://v3.vuejs.org/guide/migration/migration-build.html#overview