### PR TITLE
Issue 109: Use window.location.origin to ensure port is added

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,10 +64,10 @@ function trackMatomoPageView (options, to, from) {
   }
 
   if (referrerUrl) {
-    Matomo.setReferrerUrl(referrerUrl)
+    Matomo.setReferrerUrl(window.location.origin + referrerUrl)
   }
   if (url) {
-    Matomo.setCustomUrl(url)
+    Matomo.setCustomUrl(window.location.origin + url)
   }
 
   Matomo.trackPageView(title)


### PR DESCRIPTION
#109 

Matomo append the page url, but not with a port.