### PR TITLE
Add options to transform urls before sending.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ Vue.use(VueMatomo, {
   // Set this to include crossorigin attribute on the matomo script import
   // Default: undefined, possible values : 'anonymous', 'use-credentials'
   crossOrigin: undefined,
+
+  // Set this to a function that takes the referrer url and transforms it
+  // before sending to Matomo.
+  //
+  // For example:
+  //
+  //     (u) => { return u.split('#')[0]; }
+  //
+  referrerTransform: undefined,
+
+  // Set this to a function that takes the origin url and transforms it
+  // before sending to Matomo.
+  //
+  // See referrerTransform for example.
+  urlTransform: undefined,
 });
 
 // Now you can access piwik api in components through

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,9 @@ const defaultOptions = {
   cookieDomain: undefined,
   domains: undefined,
   preInitActions: [],
-  crossOrigin: undefined
+  crossOrigin: undefined,
+  referrerTransform: undefined,
+  urlTransform: undefined
 }
 
 export const matomoKey = 'Matomo'
@@ -60,14 +62,27 @@ function trackMatomoPageView (options, to, from) {
     }
 
     options.debug && console.debug('[vue-matomo] Tracking ' + url)
-    title = to.meta.title || url
+    title = to.meta.title || (typeof options.urlTransform === 'function'
+      ? options.urlTransform(url) : url)
   }
 
   if (referrerUrl) {
-    Matomo.setReferrerUrl(window.location.origin + referrerUrl)
+    let u = window.location.origin + referrerUrl
+    if (typeof options.referrerTransform === 'function') {
+      u = options.referrerTransform(u, referrerUrl)
+    }
+    Matomo.setReferrerUrl(u)
   }
+
   if (url) {
-    Matomo.setCustomUrl(window.location.origin + url)
+    let u = window.location.origin + url
+    if (typeof options.urlTransform === 'function') {
+      u = options.urlTransform(u, url)
+    }
+    Matomo.setCustomUrl(u)
+  } else if (typeof options.urlTransform === 'function') {
+    const u = options.urlTransform(window.location.href)
+    Matomo.setCustomUrl(u)
   }
 
   Matomo.trackPageView(title)


### PR DESCRIPTION
By default the full url is sent for tracking. This PR adds functionality to control which parts are included.

A practical use-case is to exclude the fragment parts after the `#`, since these are typically local details.

One thing I'm not sure about is the default url used (if a router is not present), assumed `window.location.href` (see change), but feel free to revise.

TEST=ran lint, eyeballed cases in network inspector